### PR TITLE
Publish container workflow

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,38 @@
+name: Publish container
+
+on:
+  push:
+    tags: '*'
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ vars.REGISTRY }}
+          username: ${{ vars.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ vars.REGISTRY }}/${{ github.repository }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Requirements:

- Repository Action Variables:

  - REGISTRY (ex. ghcr.io)
  - REGISTRY_USER (ex. octocat)

- Repository Action Secrets:

  - REGISTRY_PASSWORD

When publishing to ghcr.io, use a "classic" GH personal access token as REGISTRY_PASSWORD of the matching REGISTRY_USER account.  This token should allow at least the following scopes: "write:packages", "read:packages" and "delete:packages".

Currently the only way to make a token without access to the users repos is through a hack described here:

  https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic